### PR TITLE
changed md5 to sha256

### DIFF
--- a/imapsync.rb
+++ b/imapsync.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Imapsync < Formula
   url 'https://fedorahosted.org/released/imapsync/imapsync-1.456.tgz'
   homepage 'http://ks.lamiral.info/imapsync/'
-  md5 'e9ea9ab5eba11cfe1c62ae9be1d9d7ae'
+  sha256 '001308e082ae5f504b9f60509881c20c1dcf1f916f3b20ac53622c6bdb6af58d'
 
   depends_on 'Mail::IMAPClient' => :perl
   depends_on 'Authen::NTLM'     => :perl


### PR DESCRIPTION
brew has started to complain that the md5 hash validation was going to be deprecated in a future version. 

I pulled the tarball, did an md5 to validate it was the same that you assumed, then did an shasum -a256 and generated the SHA256 hash.  Replaced the md5 hash with the sha256 hash in the imapsync.rb file.  

Tested it all and it works.  

BTW - why has this never been merged into the main homebrew distro?

Christopher
